### PR TITLE
Enhance release workflows with --force-jit and file backup

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -65,7 +65,14 @@ jobs:
             build-runner-${{ runner.os }}-
 
       - name: Generate Code (build_runner)
-        run: dart run build_runner build -d
+        run: |
+          # Backup pre-committed generated files (see docs/CI_DECISIONS.md)
+          find . -name '*.g.dart' -not -name 'env.g.dart' -o -name '*.mocks.dart' | while read f; do cp "$f" "$f.bak"; done
+
+          dart run build_runner build --force-jit -d
+
+          # Restore backed-up files that build_runner deleted
+          find . -name '*.bak' | while read f; do mv "$f" "${f%.bak}"; done
 
       - name: Build Dev APK
         env:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -68,7 +68,14 @@ jobs:
             build-runner-${{ runner.os }}-
 
       - name: Generate Code (build_runner)
-        run: dart run build_runner build -d
+        run: |
+          # Backup pre-committed generated files (see docs/CI_DECISIONS.md)
+          find . -name '*.g.dart' -not -name 'env.g.dart' -o -name '*.mocks.dart' | while read f; do cp "$f" "$f.bak"; done
+
+          dart run build_runner build --force-jit -d
+
+          # Restore backed-up files that build_runner deleted
+          find . -name '*.bak' | while read f; do mv "$f" "${f%.bak}"; done
 
       - name: Run Quality Checks
         run: |


### PR DESCRIPTION
Same build_runner fixes as validate-pr.yml: --force-jit bypasses AOT build hooks failure, backup/restore preserves pre-committed .g.dart and .mocks.dart files.